### PR TITLE
Update EdgeUpdateAutopilot.ps1

### DIFF
--- a/Automatically Update Microsoft Edge/EdgeUpdateAutopilot.ps1
+++ b/Automatically Update Microsoft Edge/EdgeUpdateAutopilot.ps1
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------------------------- #
 # Author(s)    : Peter Klapwijk - www.InTheCloud247.com                        #
-# Version      : 1.0                                                           #
+# Contributor  : Mathieu Ait Azzouzene                                         #
+# Version      : 1.1                                                           #
 #                                                                              #
 # Description  : Updates Microsoft Edge during AP enrollment as Windows is     #
 #                delivered with an outdated Edge version                       #
@@ -8,6 +9,19 @@
 # This script is provide "As-Is" without any warranties                        #
 #                                                                              #
 # ---------------------------------------------------------------------------- #
+
+param (
+    [Parameter(Mandatory = $False)]
+    [ValidateNotNullorEmpty()]
+    [ValidateSet('Stable', 'Beta', 'Canary', 'Dev')]
+    [String]
+    $UpdateChannel = 'Stable',
+    [Parameter(Mandatory = $False)]
+    [ValidateNotNullorEmpty()]
+    [ValidateSet('x86', 'x64', 'arm64')]
+    [String]
+    $Architecture = 'x64'
+)
 
 # Microsoft Intune Management Extension might start a 32-bit PowerShell instance. If so, restart as 64-bit PowerShell
 If ($ENV:PROCESSOR_ARCHITEW6432 -eq "AMD64") {
@@ -40,30 +54,64 @@ Function CleanUpAndExit() {
     EXIT $ErrorLevel
 }
 
+$ExitCode = 0
+
 #Results stored in the registry for Intune detection. Change to your needs.
 $StoreResults = "InTheCloud247\EdgeUpdateAutopilot\v1.0"
 
+#Get Edge app GUID depending on the update channel
+switch ($UpdateChannel) {
+    'Stable' { $AppGUID = '{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}' }
+    'Beta' { $AppGUID = '{2CD8A007-E189-409D-A2C8-9AF4EF3C72AA}' }
+    'Canary' { $AppGUID = '{65C35B14-6C1D-4122-AC46-7148CC9D6497}' }
+    'Dev' { $AppGUID = '{0D50BFEC-CD6A-4F9A-964C-C7416E3ACB10}' }
+}
+
+$Platform = 'Windows'
+
 # Start Transcript
-Start-Transcript -Path "$env:ProgramData\Microsoft\IntuneManagementExtension\Logs\$($(Split-Path $PSCommandPath -Leaf).ToLower().Replace(".ps1",".log"))" | Out-Null
+Start-Transcript -Append -Path "$env:ProgramData\Microsoft\IntuneManagementExtension\Logs\$($(Split-Path $PSCommandPath -Leaf).ToLower().Replace(".ps1",".log"))" | Out-Null
 
 #Determine original Microsoft Edge Version
-$EdgeVersionOld = (Get-AppxPackage -AllUsers -Name "Microsoft.MicrosoftEdge.Stable").Version
-Write-Host "Current Microsoft Edge version $EdgeVersionOld"
+[System.Version]$EdgeVersionOld = (Get-AppxPackage -AllUsers -Name "Microsoft.MicrosoftEdge.$UpdateChannel").Version
+if (!($EdgeVersionOld)) {
+    Write-Error "Microsoft Edge $UpdateChannel not installed, exiting"
+    $ExitCode = 1
+}
+Else {
+    Write-Host "Current Microsoft Edge $UpdateChannel version $EdgeVersionOld"
+    #Determine latest Microsoft Edge Version depending on the update channel
+    $EdgeInfo = (Invoke-WebRequest -UseBasicParsing -uri 'https://edgeupdates.microsoft.com/api/products?view=enterprise')
 
-#Trigger Microsoft Edge update
-Start-Process -FilePath "C:\Program Files (x86)\Microsoft\EdgeUpdate\MicrosoftEdgeUpdate.exe" -argumentlist "/silent /install appguid={56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}&appname=Microsoft%20Edge&needsadmin=True"
-Write-Host "Sleeping for 120 seconds"
-Start-Sleep -Seconds 120
+    [System.Version]$EdgeVersionLatest = ((($EdgeInfo.content | Convertfrom-json) | Where-Object {$_.product -eq $UpdateChannel}).releases | Where-Object {$_.Platform -eq $Platform -and $_.architecture -eq $architecture})[0].productversion
+    Write-Host "Latest $UpdateChannel Microsoft Edge version is $EdgeVersionLatest"
+									 
+						
 
-# Do Until Loop to check updated Edge Version
-Do {
-    $EdgeVersionNew = (Get-AppxPackage -AllUsers -Name "Microsoft.MicrosoftEdge.Stable").Version
-    Write-Host "Checking current Edge version"
-    Start-Sleep -Seconds 15
-} Until ($EdgeVersionNew -gt 120.0.0.0)
-Write-Host "Edge version updated to $EdgeVersionNew"
+    #Check if Microsoft Edge is already up to date
+    If ($EdgeVersionOld -ge $EdgeVersionLatest) {
+        Write-Host "Microsoft Edge $UpdateChannel already up to date"
+    }
+    else {
+        #Trigger Microsoft Edge update
+        Write-Host "Launching Microsoft Edge $UpdateChannel update"
+        Start-Process -FilePath "C:\Program Files (x86)\Microsoft\EdgeUpdate\MicrosoftEdgeUpdate.exe" -argumentlist "/silent /install appguid=$AppGUID&appname=Microsoft%20Edge&needsadmin=True"
+        Write-Host "Sleeping for 60 seconds"
+        Start-Sleep -Seconds 60
 
+        #Getting new Microsoft Edge installed version
+        [System.Version]$EdgeVersionNew = (Get-AppxPackage -AllUsers -Name "Microsoft.MicrosoftEdge.$UpdateChannel").Version
 
-CleanUpAndExit -ErrorLevel 0
+        # Do While Loop to wait until Microsoft Edge Version updated if required
+        Do {
+            [System.Version]$EdgeVersionNew = (Get-AppxPackage -AllUsers -Name "Microsoft.MicrosoftEdge.$UpdateChannel").Version
+            Write-Host "Checking current Edge version"
+            Start-Sleep -Seconds 15
+        } While ($EdgeVersionNew -lt $EdgeVersionLatest)
+        Write-Host "Microsoft Edge $UpdateChannel version updated to $EdgeVersionNew"
+    }
+}
 
 Stop-Transcript
+
+CleanUpAndExit -ErrorLevel $ExitCode


### PR DESCRIPTION
Added parameters to select the Update Channel and Architecture (Default Stable x64) Added the exitcode variable to handle errors
Added "Append" to transcript
Added dynamic version comparison
Added a check for installed version before update
Changed Start-Sleep to 60 seconds since update can take less than 90 seconds Replaced Do-Until loop to a Do-while one to save time (loop won't execute if Edge already updated after 60 seconds) Fixed Stop-transcript : Cleanupandexit function exited before transcript